### PR TITLE
Make unjsx work in browsers with no fat-arrow support

### DIFF
--- a/index.js
+++ b/index.js
@@ -242,5 +242,6 @@ module.exports = function (h, opts) {
   }
 }
 
-const quot = (state) =>
-  state === ATTR_VALUE_SQ || state === ATTR_VALUE_DQ
+function quot (state) {
+  return state === ATTR_VALUE_SQ || state === ATTR_VALUE_DQ
+}


### PR DESCRIPTION
@davidmarkclements when I want to support iOS9, it is the only lib that I use that needs me to add transpilation for it, and it would be really simple to avoid it, just use a plain old function instead :wink: 

Tests are passing of course